### PR TITLE
Fix BindDispatch connector functionality to support variadic arguments.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7907,12 +7907,12 @@
     },
     "lodash": {
       "version": "4.17.10",
-      "resolved": "https://nexus.aws.averoinc.com/repository/npm-group/lodash/-/lodash-4.17.10.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash-es": {
       "version": "4.17.10",
-      "resolved": "https://nexus.aws.averoinc.com/repository/npm-group/lodash-es/-/lodash-es-4.17.10.tgz",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
       "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "types-first-ui",
-  "version": "2.1.0",
+  "version": "2.1.1-alpha.0",
   "description": "An opinionated framework for building long-lived, maintainable UI codebases",
   "main": "./dist/bundle.js",
   "types": "./dist/index.d.ts",

--- a/src/connector.test.tsx
+++ b/src/connector.test.tsx
@@ -19,8 +19,8 @@ import Adapter from 'enzyme-adapter-react-16';
 import * as React from 'react';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BoundActionCreator } from './connector';
 import createTypesafeRedux from './typesafeRedux';
+import { BoundActionCreator } from './connector';
 
 Enzyme.configure({ adapter: new Adapter() });
 const { shallow, render, mount } = Enzyme;

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -22,7 +22,6 @@ import { Action, Arg0, Dispatch } from './types';
 import { comparators } from './utils/comparators';
 import { ActionCreator } from './implementAction';
 
-// A type representing an action creator bound to the store dispatch function
 export type BoundActionCreator<
   TAllActions extends Action,
   TActionType extends TAllActions['type']
@@ -159,12 +158,12 @@ export class Connector<TState extends object, TActions extends Action> {
         };
 
         private bindDispatch = (actionCreators: TActionProps) => {
-          const boundCreators = mapValues<ActionCreator<any>, (payload) => void>(
-            actionCreators,
-            actionCreator => {
-              return payload => _dispatch(actionCreator(payload));
-            }
-          ) as TActionProps;
+          const boundCreators = mapValues<
+            (...args: any[]) => TActions,
+            (...args) => void
+          >(actionCreators, actionCreator => {
+            return (...args) => _dispatch(actionCreator(...args));
+          }) as TActionProps;
 
           if (this._isConstructor) {
             Object.assign(this.state, boundCreators);


### PR DESCRIPTION
Previously, we had constrained action creators to be unary functions of `payload => TAction`. In #19, I loosened the types to allow for action creators with any amount of arguments. However, I forgot to carry over this behavior to the `bindDispatch` function inside the connector--only the first argument was getting passed in, which became apparent when trying to use typesafe-history.

This PR updates the connector to fix this bug by passing along all arguments from the action creator.