### PR TITLE
Fix Example: Remove BoundCreator references

### DIFF
--- a/example/simple-counter/containers/App.tsx
+++ b/example/simple-counter/containers/App.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 import app from '../redux/connector';
 import { ActionTypes, AppActions } from '../redux/interfaces/actions';
 import { Paths } from '../redux/paths';
-import { BoundActionCreator } from '../../../src';
+import { Creator } from '../redux/interfaces/app';
 
 interface DataProps {
   counter: number;
 }
 
 interface ActionProps {
-  add: BoundActionCreator<AppActions, ActionTypes.COUNTER_ADD_REQUEST>;
-  subtract: BoundActionCreator<AppActions, ActionTypes.COUNTER_SUBTRACT>;
+  add: Creator<ActionTypes.COUNTER_ADD_REQUEST>;
+  subtract: Creator<ActionTypes.COUNTER_SUBTRACT>;
 }
 
 type Props = DataProps & ActionProps;

--- a/example/simple-counter/redux/interfaces/app.ts
+++ b/example/simple-counter/redux/interfaces/app.ts
@@ -1,7 +1,11 @@
-import { createTypesafeRedux } from '../../../../src';
-import { AppActions } from './actions';
+import { createTypesafeRedux, ActionCreator } from '../../../../src';
+import { AppActions, ActionTypes } from './actions';
 import { State } from './state';
 
 const { path, selector, createApp, action } = createTypesafeRedux<State, AppActions>();
 
 export { createApp, path, selector, action };
+
+export type Creator<T extends ActionTypes> = ActionCreator<
+  Extract<AppActions, { type: T }>
+>;


### PR DESCRIPTION
The counter example still had references to `BoundCreators`, which we removed in #18.