### PR TITLE
Update url-parse to fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11719,9 +11719,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "dev": true,
       "requires": {
         "querystringify": "^2.0.0",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-3774

v1.4.3 no longer has this issue. This is a dependency of webpack-dev-server -> socksjs client