### PR TITLE
Upgrade to TS@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10269,9 +10269,9 @@
       }
     },
     "rxjs": {
-      "version": "6.0.0",
-      "resolved": "https://nexus.aws.averoinc.com/repository/npm-group/rxjs/-/rxjs-6.0.0.tgz",
-      "integrity": "sha512-2MgLQr1zvks8+Kip4T6hcJdiBhV+SIvxguoWjhwtSpNPTp/5e09HJbgclCwR/nW0yWzhubM+6Q0prl8G5RuoBA==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -11439,9 +11439,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.4.tgz",
-      "integrity": "sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "redux": "^4.0.0",
     "rollup": "^0.62.0",
     "rollup-plugin-uglify": "^4.0.0",
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.3.3",
     "ts-jest": "^22.4.6",
     "ts-loader": "^4.2.0",
-    "typescript": "^2.8.4",
+    "typescript": "^3.1.1",
     "webpack": "^4.6.0",
     "webpack-cli": "^2.1.2",
     "webpack-dev-server": "^3.1.4"

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -62,7 +62,11 @@ export class Connector<TState extends object, TActions extends Action> {
     const { _state$, _dispatch } = this;
 
     return (
-      component: React.ComponentClass<TObservableProps & TActionProps & TOwnProps>
+      component: React.ComponentClass<
+        TObservableProps & TActionProps extends null
+          ? {}
+          : TActionProps & TOwnProps extends null ? {} : TOwnProps
+      >
     ): React.ComponentClass<TOwnProps> => {
       type ComponentState = TObservableProps & TActionProps;
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -59,15 +59,19 @@ export type FeaturesMapEpicDependencies<T extends FeaturesMap<T>> = {
 export type CombinedState<
   TState extends object,
   TFeaturesMap extends FeaturesMap<TFeaturesMap>
-> = TState & FeaturesMapState<TFeaturesMap>;
+> = TFeaturesMap extends null ? TState : TState & FeaturesMapState<TFeaturesMap>;
+
 export type CombinedActions<
   TActions extends Action,
   TFeaturesMap extends FeaturesMap<TFeaturesMap>
 > = TActions | FeaturesMapActions<TFeaturesMap>;
+
 export type CombinedEpicDependencies<
   TEpicDependencies extends object,
   TFeaturesMap extends FeaturesMap<TFeaturesMap>
-> = TEpicDependencies & FeaturesMapEpicDependencies<TFeaturesMap>;
+> = TFeaturesMap extends null
+  ? TEpicDependencies
+  : TEpicDependencies & FeaturesMapEpicDependencies<TFeaturesMap>;
 
 export type ReducerMap<TAllState extends object, TAllActions extends Action> = {
   [K in keyof Partial<TAllActions>]: IReducer<
@@ -180,9 +184,7 @@ export class App<
         return (state, action) => {
           const currentState = get([subTreeKey])(state);
           const nextState = reducer(currentState, action);
-          return nextState === currentState
-            ? state
-            : set([subTreeKey])(nextState)(state);
+          return nextState === currentState ? state : set([subTreeKey])(nextState)(state);
         };
       });
       reducers = Object.assign({}, reducers, featureReducers);

--- a/test/app.ts
+++ b/test/app.ts
@@ -68,7 +68,7 @@ export function makeApp(middlewareSpy: () => void) {
     lib: typeof counterLib;
   }
 
-  const redux = createTypesafeRedux<AppState, Actions[keyof Actions], null, Features>({
+  const redux = createTypesafeRedux<AppState, Actions[keyof Actions], {}, Features>({
     lib: counterLib,
   });
 

--- a/test/testability.test.ts
+++ b/test/testability.test.ts
@@ -103,9 +103,15 @@ describe('app testability', () => {
     it('should allow testing of epics', () => {
       const { epic, creator } = addNumber;
 
-      const emittedAction = epic(of(creator({ number: 10 })), {
-        getValue: () => 7,
-      });
+      const emittedAction = epic(
+        of(creator({ number: 10 })),
+        {
+          lib: {
+            getValue: () => 7,
+          },
+        },
+        null
+      );
 
       return expect(emittedAction.toPromise()).resolves.toEqual({
         type: CounterActionTypes.increment,


### PR DESCRIPTION
TypeScript 3.0 introduced a [breaking change related to intersections with null & undefined](https://blogs.msdn.microsoft.com/typescript/2018/07/30/announcing-typescript-3-0/#intersecting-with-nullundefined), which affected us in a few places where we were using `null` as a generic default. 

Because an empty object does not satisfy the constraint of our mapped/record types, the use of null still felt necessary. To avoid the behavior above, we need to add an additional case to the relevant conditional types to explicitly handle the null case. 

I have left comments below on each particular change.