### PR TITLE
Remove BoundCreator type; add SanitizeNull generic for TS 3.0 changes

### DIFF
--- a/src/connector.test.tsx
+++ b/src/connector.test.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import createTypesafeRedux from './typesafeRedux';
-import { BoundActionCreator } from './connector';
+import { ActionCreator } from './implementAction';
 
 Enzyme.configure({ adapter: new Adapter() });
 const { shallow, render, mount } = Enzyme;
@@ -87,7 +87,7 @@ function setup() {
     dev: false,
   });
 
-  type BoundCreator<T extends ActionTypes> = BoundActionCreator<Actions, T>;
+  type Creator<T extends ActionTypes> = ActionCreator<Extract<Actions, { type: T }>>;
 
   interface OwnProps {
     amount?: number;
@@ -99,8 +99,8 @@ function setup() {
   }
 
   interface ActionCreatorProps {
-    increment: BoundCreator<ActionTypes.INCREMENT>;
-    decrement: BoundCreator<ActionTypes.DECREMENT>;
+    increment: Creator<ActionTypes.INCREMENT>;
+    decrement: Creator<ActionTypes.DECREMENT>;
   }
 
   type Props = OwnProps & ObservableProps & ActionCreatorProps;

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -18,14 +18,8 @@ import { isFunction, mapValues } from 'lodash';
 import * as React from 'react';
 import { Observable, Subscription, combineLatest } from 'rxjs';
 import { map, sample } from 'rxjs/operators';
-import { Action, Arg0, Dispatch } from './types';
+import { Action, Arg0, Dispatch, SanitizeNull } from './types';
 import { comparators } from './utils/comparators';
-import { ActionCreator } from './implementAction';
-
-export type BoundActionCreator<
-  TAllActions extends Action,
-  TActionType extends TAllActions['type']
-> = (payload: Extract<TAllActions, { type: TActionType }>['payload']) => void;
 
 export type ObservableMap<TObservableMap> = {
   [K in keyof TObservableMap]: Observable<any>
@@ -63,14 +57,17 @@ export class Connector<TState extends object, TActions extends Action> {
 
     return (
       component: React.ComponentClass<
-        TObservableProps & TActionProps extends null
-          ? {}
-          : TActionProps & TOwnProps extends null ? {} : TOwnProps
+        SanitizeNull<TObservableProps> &
+          SanitizeNull<TActionProps> &
+          SanitizeNull<TOwnProps>
       >
-    ): React.ComponentClass<TOwnProps> => {
+    ): React.ComponentClass<SanitizeNull<TOwnProps>> => {
       type ComponentState = TObservableProps & TActionProps;
 
-      return class ConnectedComponent extends React.Component<TOwnProps, ComponentState> {
+      return class ConnectedComponent extends React.Component<
+        SanitizeNull<TOwnProps>,
+        ComponentState
+      > {
         // dispatchProps and observablePropValues are passed to render the wrapped component
         // private dispatchProps: TActionProps;
         // private observablePropValues: TObservableProps;

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -27,7 +27,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { pluck } from 'rxjs/operators';
 import { Connector } from './connector';
 import { ActionCreator, ActionImplementation } from './implementAction';
-import { Action, Dispatch, Epic, IReducer, MiddlewareEpic } from './types';
+import { Action, Dispatch, Epic, IReducer, MiddlewareEpic, SanitizeNull } from './types';
 import { get } from './utils/get';
 import { set } from './utils/set';
 
@@ -59,7 +59,7 @@ export type FeaturesMapEpicDependencies<T extends FeaturesMap<T>> = {
 export type CombinedState<
   TState extends object,
   TFeaturesMap extends FeaturesMap<TFeaturesMap>
-> = TFeaturesMap extends null ? TState : TState & FeaturesMapState<TFeaturesMap>;
+> = TState & SanitizeNull<FeaturesMapState<TFeaturesMap>>;
 
 export type CombinedActions<
   TActions extends Action,
@@ -69,9 +69,7 @@ export type CombinedActions<
 export type CombinedEpicDependencies<
   TEpicDependencies extends object,
   TFeaturesMap extends FeaturesMap<TFeaturesMap>
-> = TFeaturesMap extends null
-  ? TEpicDependencies
-  : TEpicDependencies & FeaturesMapEpicDependencies<TFeaturesMap>;
+> = TEpicDependencies & SanitizeNull<FeaturesMapEpicDependencies<TFeaturesMap>>;
 
 export type ReducerMap<TAllState extends object, TAllActions extends Action> = {
   [K in keyof Partial<TAllActions>]: IReducer<

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,7 @@ export type SingleActionEpic<
 
 // Utility - infers the type of the first argument of a function
 export type Arg0<T> = T extends (args0: infer R, ...any: any[]) => any ? R : never;
+
+// TODO: this does not feel like good practice. We need to re-evaluate our use of
+// generic default parameters and decide how to leverage the inference engine correctly
+export type SanitizeNull<T> = T extends null ? {} : T;


### PR DESCRIPTION
This PR addresses two things:

1. Removal of the `BoundActionCreator` generic type. We no longer have this concept, so we should expose this type.

2. Additional use of a `SanitizeNull` generic type that allows us to handle intersections with our null generic defaults. 

None of us would argue that `SanitizeNull` is a long-term solution. I will be adding issues/milestones associated with various things to be addressed in v3. For now, this seems like an okay time to take on tech debt in our type definitions.