### PR TITLE
Adds support for SFCs in the connector

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -56,12 +56,12 @@ export class Connector<TState extends object, TActions extends Action> {
     const { _state$, _dispatch } = this;
 
     return (
-      component: React.ComponentClass<
+      component: React.ComponentType<
         SanitizeNull<TObservableProps> &
           SanitizeNull<TActionProps> &
           SanitizeNull<TOwnProps>
       >
-    ): React.ComponentClass<SanitizeNull<TOwnProps>> => {
+    ): React.ComponentType<SanitizeNull<TOwnProps>> => {
       type ComponentState = TObservableProps & TActionProps;
 
       return class ConnectedComponent extends React.Component<

--- a/test/composability.test.tsx
+++ b/test/composability.test.tsx
@@ -73,7 +73,7 @@ class TestComponent extends React.Component<ObservableProps & DispatchProps> {
 }
 
 describe('composability', () => {
-  let ConnectedComponent: React.ComponentClass;
+  let ConnectedComponent: React.ComponentType;
   let middlewareSpy = jest.fn();
   let { app, counterLib, COUNTER, COUNTER_AS_STRING, state$ } = makeApp(middlewareSpy);
 
@@ -212,6 +212,6 @@ describe('composability', () => {
     const beforeState = state$.getValue();
     app.dispatch(app.actionCreator(CounterActionTypes.identity)({}));
     const nextState = state$.getValue();
-    expect(beforeState).toBe(nextState)
-  })
+    expect(beforeState).toBe(nextState);
+  });
 });


### PR DESCRIPTION
Working in logbook I realized that the connector demands a `ComponentClass`, which is too narrow.

This constrains the connector to `ComponentType`, which, from the React typings:
`type ComponentType<P = {}> = ComponentClass<P> | StatelessComponent<P>`

Added a test to confirm that everything works as expected.